### PR TITLE
Chore/release 5.0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dsUpload
 Title: Upload Functions for DataSHIELD Backends
-Version: 5.0.1
+Version: 5.0.2
 Authors@R: 
   c(person(given = "Mariska",
       family = "Slofstra",

--- a/R/enums.R
+++ b/R/enums.R
@@ -4,14 +4,14 @@
 du.enum.cohorts <- function() {
   list(
     ABCD = "abcd", ALSPAC = "alspac", AOF = "aof", BIB = "bib", BISC = "bisc", 
-    CHILD = "child", CHOP = "chop", DNBC = "dnbc", EDEN = "eden", ELFE = "elfe", 
-    ELSPAC = "elspac", ENVIRONAGE = "environage", GECKO = "gecko", 
-    GENESIS = "genesis", GENR = "genr", GENRNEXT = "genrnext", 
+    CHILD = "child", CHOP = "chop", DFBC = "dfbc", DNBC = "dnbc", EDEN = "eden", 
+    ELFE = "elfe", ELSPAC = "elspac", ENVIRONAGE = "environage", 
+    GECKO = "gecko", GENESIS = "genesis", GENR = "genr", GENRNEXT = "genrnext", 
     GENXXI = "genxxi", HBCS = "hbcs", HGS = "hgs", INMA = "inma", 
     ISGLOBAL = "isglobal", KANC = "kanc", MOBA = "moba", NBFC66 = "nfbc66", 
-    NBFC86 = "nfbc86", NINFEA = "ninfea", PELAGIE = "pelagie", RAINE = "raine", 
-    RECETOX = "recetox", RHEA = "rhea", SEPAGES = "sepages", SWS = "sws", 
-    TNG = "tng"
+    NBFC86 = "nfbc86", NINFEA = "ninfea", PCL = "pcl", PELAGIE = "pelagie", 
+    RAINE = "raine", RECETOX = "recetox", RHEA = "rhea", SEPAGES = "sepages", 
+    SWS = "sws", TNG = "tng"
   )
 }
 

--- a/R/enums.R
+++ b/R/enums.R
@@ -3,10 +3,15 @@
 #' @noRd
 du.enum.cohorts <- function() {
   list(
-    DNBC = "dnbc", GECKO = "gecko", ALSPAC = "alspac", GENR = "genr", MOBA = "moba", SWS = "sws", BIB = "bib", CHOP = "chop", ELFE = "elfe",
-    EDEN = "eden", NINFEA = "ninfea", HBCS = "hbcs", INMA = "inma", ISGLOBAL = "isglobal", NBFC66 = "nfbc66", NBFC86 = "nfbc86", RAINE = "raine", RHEA = "rhea",
-    ABCD = "abcd", BISC = "bisc", ENVIRONAGE = "environage", KANC = "kanc", PELAGIE = "pelagie", SEPAGES = "sepages", TNG = "tng", HGS = "hgs", RECETOX = "recetox", 
-    GENXXI = "genxxi", GENESIS = "genesis", CHILD = "child", AOF = "aof"
+    ABCD = "abcd", ALSPAC = "alspac", AOF = "aof", BIB = "bib", BISC = "bisc", 
+    CHILD = "child", CHOP = "chop", DNBC = "dnbc", EDEN = "eden", ELFE = "elfe", 
+    ELSPAC = "elspac", ENVIRONAGE = "environage", GECKO = "gecko", 
+    GENESIS = "genesis", GENR = "genr", GENRNEXT = "genrnext", 
+    GENXXI = "genxxi", HBCS = "hbcs", HGS = "hgs", INMA = "inma", 
+    ISGLOBAL = "isglobal", KANC = "kanc", MOBA = "moba", NBFC66 = "nfbc66", 
+    NBFC86 = "nfbc86", NINFEA = "ninfea", PELAGIE = "pelagie", RAINE = "raine", 
+    RECETOX = "recetox", RHEA = "rhea", SEPAGES = "sepages", SWS = "sws", 
+    TNG = "tng"
   )
 }
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -32,7 +32,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/TROUBLESHOOTING.html
+++ b/docs/TROUBLESHOOTING.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/articles/betaDictionaries.html
+++ b/docs/articles/betaDictionaries.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/articles/dataVersioning.html
+++ b/docs/articles/dataVersioning.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/articles/dictionaryVersioning.html
+++ b/docs/articles/dictionaryVersioning.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/articles/dsUpload.html
+++ b/docs/articles/dsUpload.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/articles/qualityControl.html
+++ b/docs/articles/qualityControl.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 
@@ -106,13 +106,13 @@
 
     <p>Slofstra M, Haakma S, Pinot de Moira A, Cornet M, Rauschert S (2023).
 <em>dsUpload: Upload Functions for DataSHIELD Backends</em>.
-R package version 5.0.1, <a href="https://github.com/lifecycle-project/ds-upload" class="external-link">https://github.com/lifecycle-project/ds-upload</a>. 
+R package version 5.0.2, <a href="https://github.com/lifecycle-project/ds-upload" class="external-link">https://github.com/lifecycle-project/ds-upload</a>. 
 </p>
     <pre>@Manual{,
   title = {dsUpload: Upload Functions for DataSHIELD Backends},
   author = {Mariska Slofstra and Sido Haakma and Angela {Pinot de Moira} and Maxime Cornet and Sebastian Rauschert},
   year = {2023},
-  note = {R package version 5.0.1},
+  note = {R package version 5.0.2},
   url = {https://github.com/lifecycle-project/ds-upload},
 }</pre>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -7,5 +7,5 @@ articles:
   dictionaryVersioning: dictionaryVersioning.html
   dsUpload: dsUpload.html
   qualityControl: qualityControl.html
-last_built: 2023-07-11T09:27Z
+last_built: 2023-07-19T14:34Z
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -7,5 +7,5 @@ articles:
   dictionaryVersioning: dictionaryVersioning.html
   dsUpload: dsUpload.html
   qualityControl: qualityControl.html
-last_built: 2023-07-19T14:34Z
+last_built: 2023-07-20T08:27Z
 

--- a/docs/reference/du.login.html
+++ b/docs/reference/du.login.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/reference/du.quality.control.html
+++ b/docs/reference/du.quality.control.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/reference/du.upload.beta.html
+++ b/docs/reference/du.upload.beta.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/reference/du.upload.html
+++ b/docs/reference/du.upload.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">dsUpload</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">5.0.2</span>
       </span>
     </div>
 


### PR DESCRIPTION
- dsUpload 5.0.2, includes the cohort_id(s) of DFBC, ELSPAC, GENRNEXT and PCL (Piccolipiù)